### PR TITLE
use TraceableValue.stringToTraceValue instead of TraceableValue[Strin…

### DIFF
--- a/core/src/main/scala/com/dwolla/tracing/ToTraceValue.scala
+++ b/core/src/main/scala/com/dwolla/tracing/ToTraceValue.scala
@@ -9,18 +9,19 @@ import natchez.{TraceValue, TraceableValue}
 object LowPriorityTraceableValueInstances extends LowPriorityTraceableValueInstances
 
 trait LowPriorityTraceableValueInstances extends LowestPriorityTraceableValueInstances {
-  implicit val unitTraceableValue: TraceableValue[Unit] = TraceableValue[String].contramap(_ => "()")
+  implicit val unitTraceableValue: TraceableValue[Unit] =
+    TraceableValue.stringToTraceValue.contramap(_ => "()")
 
-  implicit def optionalTraceValue[A: TraceableValue]: TraceableValue[Option[A]] = new TraceableValue[Option[A]] {
-    override def toTraceValue(a: Option[A]): TraceValue = a match {
-      case Some(a) => TraceableValue[A].toTraceValue(a)
-      case None => TraceValue.StringValue("None")
-    }
+  implicit def optionalTraceValue[A: TraceableValue]: TraceableValue[Option[A]] = {
+    case Some(a) => TraceableValue[A].toTraceValue(a)
+    case None => TraceValue.StringValue("None")
   }
 
-  implicit def traceValueViaJson[A: Encoder]: TraceableValue[A] = _.asJson.noSpaces
+  implicit def traceValueViaJson[A: Encoder]: TraceableValue[A] =
+    TraceableValue.stringToTraceValue.contramap(_.asJson.noSpaces)
 }
 
 trait LowestPriorityTraceableValueInstances {
-  implicit def traceValueViaShow[A: Show]: TraceableValue[A] = _.show
+  implicit def traceValueViaShow[A: Show]: TraceableValue[A] =
+    TraceableValue.stringToTraceValue.contramap(_.show)
 }


### PR DESCRIPTION
…g] to avoid infinite recursion