### PR TITLE
introduce TraceResourceLifecycleOps and syntax for TraceResourceAcqui…

### DIFF
--- a/core/shared/src/main/scala/com/dwolla/tracing/TraceResourceAcquisition.scala
+++ b/core/shared/src/main/scala/com/dwolla/tracing/TraceResourceAcquisition.scala
@@ -45,10 +45,48 @@ object TraceResourceAcquisition {
   def apply[F[_] : MonadCancelThrow, A](entryPoint: EntryPoint[F], name: String, options: Span.Options)
                                        (resource: Trace[F] => Resource[F, A])
                                        (implicit L: Local[F, Span[F]]): Resource[F, A] =
+    TraceResourceAcquisition(entryPoint, name, options, resource(natchezMtlTraceForLocal))
+
+  /**
+   * Given an entrypoint and a root span name, ensure that the acquisition
+   * and finalization phases of the passed `Resource[F, A]` are traced in
+   * separate root spans.
+   *
+   * @param entryPoint a Natchez `EntryPoint[F]` used to create the new root spans
+   * @param name       the name of the root span. a good default might be `"app initialization"`
+   * @param resource   a resource that was traced using the `Local[F, Span[F]]` passed implicitly as `L`
+   * @param L          an implicit `Local[F, Span[F]]` instance for the given effect type
+   * @tparam F the effect type in which to run
+   * @tparam A inner type of the `Resource[F, A]`
+   * @return `Resource[F, A]` that is the same as the one returned by the `resource` function, but with tracing introduced
+   */
+  def apply[F[_] : MonadCancelThrow, A](entryPoint: EntryPoint[F], name: String, resource: Resource[F, A])
+                                       (implicit L: Local[F, Span[F]]): Resource[F, A] =
+    TraceResourceAcquisition(entryPoint, name, Span.Options.Defaults, resource)
+
+  /**
+   * Given an entrypoint and a root span name, ensure that the acquisition
+   * and finalization phases of the passed `Resource[F, A]` are traced in
+   * separate root spans.
+   *
+   * @param entryPoint a Natchez `EntryPoint[F]` used to create the new root spans
+   * @param name       the name of the root span. a good default might be `"app initialization"`
+   * @param resource   a resource that was traced using the `Local[F, Span[F]]` passed implicitly as `L`
+   * @param options    options to set on the newly created root span
+   * @param L          an implicit `Local[F, Span[F]]` instance for the given effect type
+   * @tparam F the effect type in which to run
+   * @tparam A inner type of the `Resource[F, A]`
+   * @return `Resource[F, A]` that is the same as the one returned by the `resource` function, but with tracing introduced
+   */
+  def apply[F[_] : MonadCancelThrow, A](entryPoint: EntryPoint[F],
+                                        name: String,
+                                        options: Span.Options,
+                                        resource: Resource[F, A])
+                                       (implicit L: Local[F, Span[F]]): Resource[F, A] =
     Resource {
       entryPoint
         .runInRoot(name, options) {
-          resource(natchezMtlTraceForLocal)
+          resource
             .allocated
             .nested
             .map { fa =>

--- a/core/shared/src/main/scala/com/dwolla/tracing/syntax/TraceResourceLifecycleOps.scala
+++ b/core/shared/src/main/scala/com/dwolla/tracing/syntax/TraceResourceLifecycleOps.scala
@@ -1,0 +1,57 @@
+package com.dwolla.tracing.syntax
+
+import cats.effect.{MonadCancelThrow, Resource}
+import cats.mtl.Local
+import cats.syntax.all._
+import com.dwolla.tracing.TraceResourceAcquisition
+import natchez.{EntryPoint, Span, Trace}
+
+trait ToTraceResourceLifecycleOps {
+  implicit def toTraceResourceLifecycleOps[F[_], A](resource: Resource[F, A]): TraceResourceLifecycleOps[F, A] =
+    new TraceResourceLifecycleOps(resource)
+}
+
+class TraceResourceLifecycleOps[F[_], A](val resource: Resource[F, A]) extends AnyVal {
+  /**
+   * Wrap the acquisition and release phases of the given `Resource[F, A]`
+   * in children spans of the given `Trace[F]`.
+   *
+   * Note: this requires a `Trace[F]` built from `Local[F, Span[F]]`
+   * (e.g. using `natchez.mtl.natchezMtlTraceForLocal`) or
+   * `Trace[Kleisli[F, Span[F], *]]`. Notably, the `natchez.Trace.ioTrace`
+   * instance is *not* compatible with this method.
+   *
+   * @param name the base of the span name to use for acquisition (the finalization span will append ".finalize" to this value to form its span name)
+   * @param F    a `MonadCancelThrow[F]` instance for the given effect type
+   * @param T    a `Trace[F]` for the given effect type. See the note in the description above; not every `Trace[F]` instance will work
+   * @return the input `Resource[F, A]` with its acquisition and release phases wrapped in Natchez spans
+   */
+  def traceResourceLifecycleAs(name: String)
+                              (implicit F: MonadCancelThrow[F],
+                               T: Trace[F]): Resource[F, A] =
+    Resource {
+      Trace[F].spanR(name)
+        .use(_(resource.allocated))
+        .nested
+        .map(f => Trace[F].spanR(s"$name.finalize").use(_(f)))
+        .value
+    }
+
+  /**
+   * Given an entrypoint and a root span name, ensure that the acquisition
+   * and finalization phases of the passed `Resource[F, A]` are traced in
+   * separate root spans.
+   *
+   * @param name       the base of the span name to use for acquisition (the finalization span will append ".finalize" to this value to form its span name)
+   * @param entryPoint an `EntryPoint[F]` capable of creating new root spans
+   * @param F          a `MonadCancelThrow[F]` instance for the given effect type
+   * @param L          a `Local[F, Span[F]]` instance for the given effect type
+   * @return the input `Resource[F, A]` with its acquisition and release phases wrapped in Natchez root spans
+   */
+  def traceResourceLifecycleInRootSpans(name: String,
+                                        entryPoint: EntryPoint[F])
+                                       (implicit
+                                        F: MonadCancelThrow[F],
+                                        L: Local[F, Span[F]]): Resource[F, A] =
+    TraceResourceAcquisition(entryPoint, name, resource)
+}

--- a/core/shared/src/main/scala/com/dwolla/tracing/syntax/package.scala
+++ b/core/shared/src/main/scala/com/dwolla/tracing/syntax/package.scala
@@ -7,3 +7,4 @@ package object syntax
     with ToInstrumentableAndTraceableOps
     with ToTraceParamsOps
     with ToEntryPointRootScopeOps
+    with ToTraceResourceLifecycleOps

--- a/core/shared/src/test/scala/com/dwolla/tracing/TraceInitializationSpec.scala
+++ b/core/shared/src/test/scala/com/dwolla/tracing/TraceInitializationSpec.scala
@@ -1,10 +1,10 @@
 package com.dwolla.tracing
 
 import cats._
-import cats.effect.syntax.all._
 import cats.effect.{MonadCancelThrow, Resource, Trace => _}
 import cats.mtl.Local
 import cats.syntax.all._
+import com.dwolla.tracing.syntax.toTraceResourceLifecycleOps
 import natchez.InMemory.Lineage.Root
 import natchez.InMemory.NatchezCommand._
 import natchez.InMemory.{Lineage, NatchezCommand}
@@ -38,27 +38,28 @@ object FakeAlg {
 }
 
 class TraceInitializationSpec extends InMemorySuite {
-  traceTest("TraceResourceAcquisition", new TraceTest {
-    private def resources[F[_] : Applicative : Trace]: Resource[F, FakeAlg[F]] =
-      Trace[F].span("resource acquisition")(().pure[F])
-        .toResource
-        .onFinalize(Trace[F].span("resource finalizer")(().pure[F]))
-        .as(FakeAlg[F])
+  trait TraceResourceAcquisitionTest extends TraceTest {
+    val name = "test"
 
-    override def program[F[_] : MonadCancelThrow](entryPoint: EntryPoint[F])
-                                                 (implicit L: Local[F, Span[F]]): F[Unit] =
-      TraceResourceAcquisition(entryPoint, "test") { implicit trace =>
-        resources
-      }.use { alg =>
-        AppRoot(entryPoint, alg).handleRequest
-      }
+    def resourceA[F[_]]: Resource[F, Unit] =
+      Resource.unit[F]
 
-    override def expectedHistory: List[(Lineage, NatchezCommand)] =
+    def resourceB[F[_] : Applicative : Trace]: Resource[F, FakeAlg[F]] =
+      Resource.pure(FakeAlg[F])
+
+    def use[F[_] : MonadCancelThrow](entryPoint: EntryPoint[F])
+                                    (alg: FakeAlg[F])
+                                    (implicit L: Local[F, Span[F]]): F[Unit] =
+      AppRoot(entryPoint, alg).handleRequest
+
+    override def expectedHistory: List[(Lineage, NatchezCommand)] = {
       List(
-        Root -> CreateRootSpan("test", Kernel(Map.empty), Span.Options.Defaults),
-        Root("test") -> CreateSpan("resource acquisition", None, Span.Options.Defaults),
-        Root("test") -> ReleaseSpan("resource acquisition"),
-        Root -> ReleaseRootSpan("test"),
+        Root -> CreateRootSpan(name, Kernel(Map.empty), Span.Options.Defaults),
+        Root(name) -> CreateSpan("resource a", None, Span.Options.Defaults),
+        Root(name) -> ReleaseSpan("resource a"),
+        Root(name) -> CreateSpan("resource b", None, Span.Options.Defaults),
+        Root(name) -> ReleaseSpan("resource b"),
+        Root -> ReleaseRootSpan(name),
 
         Root -> CreateRootSpan("app root", Kernel(Map.empty), Span.Options.Defaults),
         Root("app root") -> CreateSpan("app root child", None, Span.Options.Defaults),
@@ -67,10 +68,43 @@ class TraceInitializationSpec extends InMemorySuite {
         Root("app root") -> ReleaseSpan("app root child"),
         Root -> ReleaseRootSpan("app root"),
 
-        Root -> CreateRootSpan("test.finalize", Kernel(Map.empty), Span.Options.Defaults),
-        Root("test.finalize") -> CreateSpan("resource finalizer", None, Span.Options.Defaults),
-        Root("test.finalize") -> ReleaseSpan("resource finalizer"),
-        Root -> ReleaseRootSpan("test.finalize"),
+        Root -> CreateRootSpan(s"$name.finalize", Kernel(Map.empty), Span.Options.Defaults),
+        Root(s"$name.finalize") -> CreateSpan("resource b.finalize", None, Span.Options.Defaults),
+        Root(s"$name.finalize") -> ReleaseSpan("resource b.finalize"),
+        Root(s"$name.finalize") -> CreateSpan("resource a.finalize", None, Span.Options.Defaults),
+        Root(s"$name.finalize") -> ReleaseSpan("resource a.finalize"),
+        Root -> ReleaseRootSpan(s"$name.finalize"),
       )
+    }
+  }
+
+  traceTest("TraceResourceAcquisition via Trace[F]", new TraceResourceAcquisitionTest {
+    private def resources[F[_] : MonadCancelThrow : Trace]: Resource[F, FakeAlg[F]] =
+      for {
+        _ <- resourceA[F].traceResourceLifecycleAs("resource a")
+        alg <- resourceB[F].traceResourceLifecycleAs("resource b")
+      } yield alg
+
+    override def program[F[_] : MonadCancelThrow](entryPoint: EntryPoint[F])
+                                                 (implicit L: Local[F, Span[F]]): F[Unit] =
+      TraceResourceAcquisition(entryPoint, "test") { implicit trace =>
+        resources
+      }.use(use(entryPoint))
+  })
+
+  traceTest("TraceResourceAcquisition via Local[F, Span[F]]", new TraceResourceAcquisitionTest {
+    import natchez.mtl._
+
+    private def resources[F[_] : MonadCancelThrow](implicit L: Local[F, Span[F]]): Resource[F, FakeAlg[F]] =
+      for {
+        _ <- resourceA[F].traceResourceLifecycleAs("resource a")
+        alg <- resourceB[F].traceResourceLifecycleAs("resource b")
+      } yield alg
+
+    override def program[F[_] : MonadCancelThrow](entryPoint: EntryPoint[F])
+                                                 (implicit L: Local[F, Span[F]]): F[Unit] = {
+      resources.traceResourceLifecycleInRootSpans("test", entryPoint)
+        .use(use(entryPoint))
+    }
   })
 }


### PR DESCRIPTION
…sition where the `Trace[F]` comes from the `Local[F, Span[F]]`