### PR TITLE
Best-Effort Tracing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,10 +47,11 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
     libraryDependencies ++= Seq(
       "org.tpolecat" %%% "natchez-core" % "0.3.4",
       "org.tpolecat" %%% "natchez-mtl" % "0.3.4",
-      "org.tpolecat" %%% "natchez-testkit" % "0.3.4" % Test,
       "org.typelevel" %%% "cats-tagless-core" % "0.15.0",
       "org.typelevel" %%% "cats-mtl" % "1.4.0",
+      "org.typelevel" %%% "log4cats-noop" % "2.6.0",
       "io.circe" %%% "circe-core" % "0.14.6",
+      "org.tpolecat" %%% "natchez-testkit" % "0.3.4" % Test,
       "org.typelevel" %% "munit-cats-effect" % "2.0.0-M4" % Test,
       "org.typelevel" %% "scalacheck-effect" % "2.0.0-M2" % Test,
       "org.typelevel" %% "scalacheck-effect-munit" % "2.0.0-M2" % Test,

--- a/core/jvm/src/test/scala/com/dwolla/tracing/TraceInitializationExample.scala
+++ b/core/jvm/src/test/scala/com/dwolla/tracing/TraceInitializationExample.scala
@@ -1,16 +1,20 @@
 package com.dwolla.tracing
 
-import cats._
-import cats.data._
-import cats.effect.std._
-import cats.effect.syntax.all._
-import cats.effect.{IO, Resource, Trace => _, _}
-import cats.syntax.all._
-import com.dwolla.tracing.instances._
+import cats.*
+import cats.data.*
+import cats.effect.std.*
+import cats.effect.syntax.all.*
+import cats.effect.{IO, Resource, Trace as _, *}
+import cats.syntax.all.*
+import com.dwolla.tracing.instances.*
 import natchez.{EntryPoint, Span, Trace}
 import natchez.mtl.localSpanForKleisli
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.noop.NoOpLogger
 
 object TraceInitializationExample extends IOApp.Simple {
+  private implicit def logger[F[_] : Applicative]: Logger[F] = NoOpLogger[F]
+
   private def entryPoint[F[_] : Sync : Env]: Resource[F, EntryPoint[F]] =
     OpenTelemetryAtDwolla[F]("TraceInitializationSpec", DwollaEnvironment.Local)
 

--- a/core/shared/src/main/scala-2.13+/com/dwolla/tracing/syntax/TraceResourceLifecycleOps.scala
+++ b/core/shared/src/main/scala-2.13+/com/dwolla/tracing/syntax/TraceResourceLifecycleOps.scala
@@ -1,0 +1,68 @@
+package com.dwolla.tracing.syntax
+
+import cats.effect.{MonadCancelThrow, Resource}
+import cats.mtl.Local
+import cats.syntax.all.*
+import com.dwolla.tracing.TraceResourceAcquisition
+import natchez.{EntryPoint, Span, Trace}
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.noop.NoOpLogger
+
+trait ToTraceResourceLifecycleOps {
+  implicit def toTraceResourceLifecycleOps[F[_], A](resource: Resource[F, A]): TraceResourceLifecycleOps[F, A] =
+    new TraceResourceLifecycleOps(resource)
+}
+
+class TraceResourceLifecycleOps[F[_], A](val resource: Resource[F, A]) extends AnyVal {
+  /**
+   * Wrap the acquisition and release phases of the given `Resource[F, A]`
+   * in children spans of the given `Trace[F]`.
+   *
+   * Note: this requires a `Trace[F]` built from `Local[F, Span[F]]`
+   * (e.g. using `natchez.mtl.natchezMtlTraceForLocal`) or
+   * `Trace[Kleisli[F, Span[F], *]]`. Notably, the `natchez.Trace.ioTrace`
+   * instance is *not* compatible with this method.
+   *
+   * @param name the base of the span name to use for acquisition (the finalization span will append ".finalize" to this value to form its span name)
+   * @param F    a `MonadCancelThrow[F]` instance for the given effect type
+   * @param T    a `Trace[F]` for the given effect type. See the note in the description above; not every `Trace[F]` instance will work
+   * @return the input `Resource[F, A]` with its acquisition and release phases wrapped in Natchez spans
+   */
+  def traceResourceLifecycleAs(name: String)
+                              (implicit F: MonadCancelThrow[F],
+                               T: Trace[F]): Resource[F, A] =
+    Resource {
+      Trace[F].spanR(name)
+        .use(_(resource.allocated))
+        .map { case (a, finalizer) =>
+          a -> Trace[F].spanR(s"$name.finalize").use(_(finalizer))
+        }
+    }
+
+  @deprecated("use variant accepting Logger[F]", "0.2.5")
+  def traceResourceLifecycleInRootSpans(name: String,
+                                        entryPoint: EntryPoint[F],
+                                        F: MonadCancelThrow[F],
+                                        L: Local[F, Span[F]]): Resource[F, A] =
+    TraceResourceAcquisition(entryPoint, name, resource)(F, L, NoOpLogger(F))
+
+  /**
+   * Given an entrypoint and a root span name, ensure that the acquisition
+   * and finalization phases of the passed `Resource[F, A]` are traced in
+   * separate root spans.
+   *
+   * @param name       the base of the span name to use for acquisition (the finalization span will append ".finalize" to this value to form its span name)
+   * @param entryPoint an `EntryPoint[F]` capable of creating new root spans
+   * @param F          a `MonadCancelThrow[F]` instance for the given effect type
+   * @param L1         an implicit `Local[F, Span[F]]` instance for the given effect type
+   * @param L2         an implicit `Logger[F]` instance for the given effect type
+   * @return the input `Resource[F, A]` with its acquisition and release phases wrapped in Natchez root spans
+   */
+  def traceResourceLifecycleInRootSpans(name: String,
+                                        entryPoint: EntryPoint[F])
+                                       (implicit
+                                        F: MonadCancelThrow[F],
+                                        L1: Local[F, Span[F]],
+                                        L2: Logger[F]): Resource[F, A] =
+    TraceResourceAcquisition(entryPoint, name, resource)
+}

--- a/core/shared/src/main/scala/com/dwolla/tracing/syntax/EntryPointRootScope.scala
+++ b/core/shared/src/main/scala/com/dwolla/tracing/syntax/EntryPointRootScope.scala
@@ -1,10 +1,13 @@
 package com.dwolla.tracing.syntax
 
+import cats.effect.syntax.all.*
 import cats.effect.kernel.Poll
 import cats.syntax.all.*
 import cats.effect.{MonadCancelThrow, Resource}
 import cats.mtl.*
 import natchez.*
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.noop.NoOpLogger
 
 trait ToEntryPointRootScopeOps {
   implicit def toEntryPointRootScopeOps[F[_]](entryPoint: EntryPoint[F]): EntryPointRootScopeOps[F] =
@@ -12,55 +15,91 @@ trait ToEntryPointRootScopeOps {
 }
 
 class EntryPointRootScopeOps[F[_]](val entryPoint: EntryPoint[F]) extends AnyVal {
+  @deprecated("use variant accepting Logger[F]", "0.2.5")
+  private[syntax] def runInRoot[A](name: String, fa: F[A], F: MonadCancelThrow[F], L: Local[F, Span[F]]): F[A] =
+    runInRoot(name)(fa)(F, L, NoOpLogger(F))
+
+  @deprecated("use variant accepting Logger[F]", "0.2.5")
+  private[syntax] def runInRoot[A](name: String, options: Span.Options, fa: F[A], F: MonadCancelThrow[F], L: Local[F, Span[F]]): F[A] =
+    safeSpan(fa)(_.root(name, options))(F, L, NoOpLogger(F))
+
   def runInRoot[A](name: String)
                   (fa: F[A])
                   (implicit F: MonadCancelThrow[F],
-                   L: Local[F, Span[F]]): F[A] =
+                   L1: Local[F, Span[F]],
+                   L2: Logger[F],
+                  ): F[A] =
     runInRoot(name, Span.Options.Defaults)(fa)
 
   def runInRoot[A](name: String, options: Span.Options)
                   (fa: F[A])
                   (implicit F: MonadCancelThrow[F],
-                   L: Local[F, Span[F]],
+                   L1: Local[F, Span[F]],
+                   L2: Logger[F],
                   ): F[A] =
     safeSpan(fa)(_.root(name, options))
+
+  @deprecated("use variant accepting Logger[F]", "0.2.5")
+  private[syntax] def runInContinuation[A](name: String, kernel: Kernel, fa: F[A], F: MonadCancelThrow[F], L: Local[F, Span[F]]): F[A] =
+    runInContinuation(name, kernel, Span.Options.Defaults)(fa)(F, L, NoOpLogger(F))
+
+  @deprecated("use variant accepting Logger[F]", "0.2.5")
+  private[syntax] def runInContinuation[A](name: String, kernel: Kernel, options: Span.Options, fa: F[A], F: MonadCancelThrow[F], L: Local[F, Span[F]]): F[A] =
+    safeSpan(fa)(_.continue(name, kernel, options))(F, L, NoOpLogger(F))
 
   def runInContinuation[A](name: String, kernel: Kernel)
                           (fa: F[A])
                           (implicit F: MonadCancelThrow[F],
-                           L: Local[F, Span[F]]): F[A] =
+                           L1: Local[F, Span[F]],
+                           L2: Logger[F],
+                          ): F[A] =
     runInContinuation(name, kernel, Span.Options.Defaults)(fa)
 
   def runInContinuation[A](name: String, kernel: Kernel, options: Span.Options)
                           (fa: F[A])
                           (implicit F: MonadCancelThrow[F],
-                           L: Local[F, Span[F]]): F[A] =
+                           L1: Local[F, Span[F]],
+                           L2: Logger[F],
+                          ): F[A] =
     safeSpan(fa)(_.continue(name, kernel, options))
 
+  @deprecated("use variant accepting Logger[F]", "0.2.5")
+  private[syntax] def runInContinuationOrElseRoot[A](name: String, kernel: Kernel, fa: F[A], F: MonadCancelThrow[F], L: Local[F, Span[F]]): F[A] =
+    runInContinuationOrElseRoot(name, kernel, Span.Options.Defaults)(fa)(F, L, NoOpLogger(F))
+
+  @deprecated("use variant accepting Logger[F]", "0.2.5")
+  private[syntax] def runInContinuationOrElseRoot[A](name: String, kernel: Kernel, options: Span.Options, fa: F[A], F: MonadCancelThrow[F], L: Local[F, Span[F]]): F[A] =
+    safeSpan(fa)(_.continueOrElseRoot(name, kernel, options))(F, L, NoOpLogger(F))
+
   def runInContinuationOrElseRoot[A](name: String, kernel: Kernel)
-                           (fa: F[A])
-                           (implicit F: MonadCancelThrow[F],
-                            L: Local[F, Span[F]]): F[A] =
+                                    (fa: F[A])
+                                    (implicit F: MonadCancelThrow[F],
+                                     L1: Local[F, Span[F]],
+                                     L2: Logger[F],
+                                    ): F[A] =
     runInContinuationOrElseRoot(name, kernel, Span.Options.Defaults)(fa)
 
   def runInContinuationOrElseRoot[A](name: String, kernel: Kernel, options: Span.Options)
                                     (fa: F[A])
                                     (implicit F: MonadCancelThrow[F],
-                                     L: Local[F, Span[F]]): F[A] =
+                                     L1: Local[F, Span[F]],
+                                     L2: Logger[F],
+                                    ): F[A] =
     safeSpan(fa)(_.continueOrElseRoot(name, kernel, options))
 
   private def safeSpan[A](fa: F[A])
                          (f: EntryPoint[F] => Resource[F, Span[F]])
                          (implicit F: MonadCancelThrow[F],
-                          L: Local[F, Span[F]]): F[A] =
+                          L1: Local[F, Span[F]],
+                          L2: Logger[F]): F[A] =
     Resource.applyFull { (poll: Poll[F]) =>
       poll {
         f(entryPoint)
-          .handleError(_ => Span.noop[F])
+          .handleErrorWith(Logger[F].warn(_: Throwable)("an error occurred initializing tracing").as(Span.noop[F]).toResource)
           .allocatedCase
       }.map {
         case (a, release) =>
-          (a, release.andThen(_.handleError(_ => ())))
+          (a, release.andThen(_.handleErrorWith(Logger[F].warn(_)("an error occurred initializing tracing"))))
       }
     }
       .use(Local[F, Span[F]].scope(fa))

--- a/core/shared/src/test/scala/com/dwolla/tracing/EntryPointRootScopeOpsSpec.scala
+++ b/core/shared/src/test/scala/com/dwolla/tracing/EntryPointRootScopeOpsSpec.scala
@@ -1,13 +1,15 @@
 package com.dwolla.tracing
 
-import cats.effect.{MonadCancelThrow, Trace => _}
+import cats.ApplicativeThrow
+import cats.effect.{IO, MonadCancelThrow, Resource, Trace as _}
 import cats.mtl.Local
-import com.dwolla.tracing.syntax._
+import cats.syntax.all.*
+import com.dwolla.tracing.syntax.*
+import natchez.*
 import natchez.InMemory.Lineage.Root
-import natchez.InMemory.NatchezCommand._
+import natchez.InMemory.NatchezCommand.*
 import natchez.InMemory.{Lineage, NatchezCommand}
-import natchez._
-import natchez.mtl._
+import natchez.mtl.*
 
 class EntryPointRootScopeOpsSpec extends InMemorySuite {
 
@@ -26,4 +28,64 @@ class EntryPointRootScopeOpsSpec extends InMemorySuite {
       )
   })
 
+  testWithLocalSpan("runInRoot succeeds even if finalization fails") { implicit L =>
+    new FailOnFinalizationEntryPoint[IO].runInRoot("moot") {
+      IO.unit
+    }
+  }
+
+  testWithLocalSpan("runInRoot succeeds even if initialization fails") { implicit L =>
+    new FailOnInitializationEntryPoint[IO].runInRoot("moot") {
+        IO.pure(42)
+      }
+      .map(assertEquals(_, 42))
+  }
+
+  testWithLocalSpan("runInContinuation succeeds even if finalization fails") { implicit L =>
+    new FailOnFinalizationEntryPoint[IO].runInContinuation("moot", Kernel(Map.empty)) {
+      IO.unit
+    }
+  }
+
+  testWithLocalSpan("runInContinuation succeeds even if initialization fails") { implicit L =>
+    new FailOnInitializationEntryPoint[IO].runInContinuation("moot", Kernel(Map.empty)) {
+        IO.pure(42)
+      }
+      .map(assertEquals(_, 42))
+  }
+
+  testWithLocalSpan("runInContinuationOrElseRoot succeeds even if finalization fails") { implicit L =>
+    new FailOnFinalizationEntryPoint[IO].runInContinuationOrElseRoot("moot", Kernel(Map.empty)) {
+      IO.unit
+    }
+  }
+
+  testWithLocalSpan("runInContinuationOrElseRoot succeeds even if initialization fails") { implicit L =>
+    new FailOnInitializationEntryPoint[IO].runInContinuationOrElseRoot("moot", Kernel(Map.empty)) {
+        IO.pure(42)
+      }
+      .map(assertEquals(_, 42))
+  }
+}
+
+class FailOnFinalizationEntryPoint[F[_] : ApplicativeThrow] extends EntryPoint[F] {
+  private def failOnFinalization: Resource[F, Span[F]] =
+    Resource.make(Span.noop[F].pure[F]) { _ =>
+      new RuntimeException("boom").raiseError[F, Unit]
+    }
+
+  override def root(name: String, options: Span.Options): Resource[F, Span[F]] = failOnFinalization
+  override def continue(name: String, kernel: Kernel, options: Span.Options): Resource[F, Span[F]] = failOnFinalization
+  override def continueOrElseRoot(name: String, kernel: Kernel, options: Span.Options): Resource[F, Span[F]] = failOnFinalization
+}
+
+class FailOnInitializationEntryPoint[F[_] : ApplicativeThrow] extends EntryPoint[F] {
+  private def failOnInitialization: Resource[F, Span[F]] =
+    Resource.make(new RuntimeException("boom").raiseError[F, Span[F]]) { _ =>
+      ().pure[F]
+    }
+
+  override def root(name: String, options: Span.Options): Resource[F, Span[F]] = failOnInitialization
+  override def continue(name: String, kernel: Kernel, options: Span.Options): Resource[F, Span[F]] = failOnInitialization
+  override def continueOrElseRoot(name: String, kernel: Kernel, options: Span.Options): Resource[F, Span[F]] = failOnInitialization
 }

--- a/core/shared/src/test/scala/com/dwolla/tracing/EntryPointRootScopeOpsSpec.scala
+++ b/core/shared/src/test/scala/com/dwolla/tracing/EntryPointRootScopeOpsSpec.scala
@@ -12,7 +12,6 @@ import natchez.InMemory.{Lineage, NatchezCommand}
 import natchez.mtl.*
 
 class EntryPointRootScopeOpsSpec extends InMemorySuite {
-
   traceTest("EntryPointRootScopeOps", new TraceTest {
     override def program[F[_] : MonadCancelThrow](entryPoint: EntryPoint[F])
                                                  (implicit L: Local[F, Span[F]]): F[Unit] =

--- a/core/shared/src/test/scala/com/dwolla/tracing/InMemorySuite.scala
+++ b/core/shared/src/test/scala/com/dwolla/tracing/InMemorySuite.scala
@@ -8,8 +8,12 @@ import cats.syntax.all.*
 import munit.CatsEffectSuite
 import natchez.InMemory.{Lineage, NatchezCommand}
 import natchez.*
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.noop.NoOpLogger
 
 trait InMemorySuite extends CatsEffectSuite {
+  protected implicit def logger[F[_] : Applicative]: Logger[F] = NoOpLogger[F]
+
   trait TraceTest {
     def program[F[_] : MonadCancelThrow](entryPoint: EntryPoint[F])
                                         (implicit L: Local[F, Span[F]]): F[Unit]

--- a/core/shared/src/test/scala/com/dwolla/tracing/InMemorySuite.scala
+++ b/core/shared/src/test/scala/com/dwolla/tracing/InMemorySuite.scala
@@ -23,6 +23,13 @@ trait InMemorySuite extends CatsEffectSuite {
     test(s"$name - IOLocal")(testTraceIoLocal(implicit L => tt.program[IO], tt.expectedHistory))
   }
 
+  def testWithLocalSpan[A](name: String)(body: Local[IO, Span[IO]] => IO[A]): Unit =
+    test(name) {
+      IOLocal(Span.noop[IO])
+        .map(localViaIoLocal(_))
+        .flatMap(body)
+    }
+
   implicit def localSpan[F[_]](implicit F: MonadCancel[F, ?]): Local[Kleisli[F, Span[F], *], Span[Kleisli[F, Span[F], *]]] =
     new Local[Kleisli[F, Span[F], *], Span[Kleisli[F, Span[F], *]]] {
       override def local[A](fa: Kleisli[F, Span[F], A])
@@ -67,7 +74,7 @@ trait InMemorySuite extends CatsEffectSuite {
     }
 
   // from https://github.com/armanbilge/oxidized/blob/412be9cd0a60b901fd5f9157ea48bda8632c5527/core/src/main/scala/oxidized/instances/io.scala#L34-L43
-  private def localViaIoLocal[E](implicit ioLocal: IOLocal[E]): Local[IO, E] =
+  protected def localViaIoLocal[E](implicit ioLocal: IOLocal[E]): Local[IO, E] =
     new Local[IO, E] {
       override def local[A](fa: IO[A])(f: E => E): IO[A] =
         ioLocal.get.flatMap { initial =>


### PR DESCRIPTION
If tracing is unavailable for some reason, we don't want the overall program to fail; rather, we just want to ignore the tracing failure and continue on. This does so, emitting a log message when the failure occurs.