### PR TITLE
add WeaveKnot to give instrumented algebras a way to call their own instrumented metthods

### DIFF
--- a/core/shared/src/main/scala/com/dwolla/tagless/WeaveKnot.scala
+++ b/core/shared/src/main/scala/com/dwolla/tagless/WeaveKnot.scala
@@ -1,0 +1,38 @@
+package com.dwolla.tagless
+
+import cats.*
+import cats.tagless.aop.*
+import cats.tagless.syntax.all.*
+
+/** Utility object for creating a fixed-point instance of a parametric algebra, allowing for transformations to be
+ * applied before the instance is fully constructed. It supports instrumenting method calls or weaving cross-cutting
+ * aspects into the algebra.
+ *
+ * Without this kind of utility, transformations applied to an instance will not be used when one of the instance's
+ * methods calls another method on the instance.
+ */
+object WeaveKnot {
+  def instrument[Alg[_[_]], F[_]](constructor: Eval[Alg[F]] => Alg[F],
+                                  transformation: Instrumentation[F, *] ~> F)
+                                 (implicit I: Instrument[Alg]): Alg[F] =
+    WeaveKnot(constructor)(_.instrument.mapK(transformation))
+
+  def weave[Alg[_[_]], F[_], Dom[_], Cod[_]](constructor: Eval[Alg[F]] => Alg[F],
+                                             transformation: Aspect.Weave[F, Dom, Cod, *] ~> F)
+                                            (implicit A: Aspect[Alg, Dom, Cod]): Alg[F] =
+    WeaveKnot(constructor)(_.weave.mapK(transformation))
+
+  def apply[Alg[_[_]], F[_]](constructor: Eval[Alg[F]] => Alg[F])
+                            (transform: Alg[F] => Alg[F]): Alg[F] = {
+    lazy val self: Alg[F] = {
+      // Capture the transformed instance in an `Eval.later` so that it's available inside
+      // the instance. This lets implementation methods call the transformed variant of
+      // the other methods on the instance.
+      val evalSelfLater = Eval.later(self)
+
+      transform(constructor(evalSelfLater))
+    }
+
+    self
+  }
+}

--- a/core/shared/src/test/scala/com/dwolla/tagless/WeaveKnotSpec.scala
+++ b/core/shared/src/test/scala/com/dwolla/tagless/WeaveKnotSpec.scala
@@ -1,0 +1,104 @@
+package com.dwolla.tagless
+
+import cats.*
+import cats.data.*
+import cats.syntax.all.*
+import cats.tagless.Trivial
+import cats.tagless.aop.*
+import cats.tagless.syntax.all.*
+import munit.{FunSuite, ScalaCheckSuite}
+import org.scalacheck.{Gen, Prop}
+
+class WeaveKnotSpec extends FunSuite with ScalaCheckSuite {
+  test("naive implementation doesn't accumulate all the method calls") {
+    val (methods, output) =
+      MyAlgebra.naive[Writer[List[String], *]]
+        .instrument
+        .mapK(new WriteInstrumentation[Id])
+        .fooReverse
+        .run
+
+    assertEquals(methods, List("MyAlgebra.fooReverse"))
+    assertEquals(output, "oof")
+  }
+
+  test("implementation using WeaveKnot does accumulate all the method calls") {
+    Prop.forAllNoShrink(Gen.asciiPrintableStr) { s =>
+      val (methods, output) =
+        WeaveKnot(MyAlgebra[Writer[List[String], *]](s))(_.instrument.mapK(new WriteInstrumentation[Id]))
+          .fooReverse
+          .run
+
+      assertEquals(output, s.reverse)
+      assertEquals(methods, List("MyAlgebra.fooReverse", "MyAlgebra.foo"))
+    }
+  }
+
+  test("implementation using WeaveKnot.instrument accumulates all the method calls") {
+    Prop.forAllNoShrink(Gen.asciiPrintableStr) { s =>
+      val (methods, output) =
+        WeaveKnot.instrument(MyAlgebra[Writer[List[String], *]](s), new WriteInstrumentation[Id])
+          .fooReverse
+          .run
+
+      assertEquals(output, s.reverse)
+      assertEquals(methods, List("MyAlgebra.fooReverse", "MyAlgebra.foo"))
+    }
+  }
+
+  test("implementation using WeaveKnot.aspect accumulates all the method calls") {
+    Prop.forAllNoShrink(Gen.asciiPrintableStr) { s =>
+      val (methods, output) =
+        WeaveKnot.weave(MyAlgebra[Writer[List[String], *]](s), new WriteWeave[Id])
+          .fooReverse
+          .run
+
+      assertEquals(output, s.reverse)
+      assertEquals(methods, List("MyAlgebra.fooReverse", "MyAlgebra.foo"))
+    }
+  }
+
+}
+
+trait MyAlgebra[F[_]] {
+  def foo: F[String]
+  def fooReverse: F[String]
+}
+
+object MyAlgebra {
+  def apply[F[_] : Applicative](s: String): Eval[MyAlgebra[F]] => MyAlgebra[F] = self =>
+    new MyAlgebra[F] {
+      override def foo: F[String] = s.pure[F]
+      override def fooReverse: F[String] =
+        self.value.foo.map(_.reverse)
+    }
+
+  def naive[F[_] : Applicative]: MyAlgebra[F] = new MyAlgebra[F] {
+    override def foo: F[String] = "foo".pure[F]
+    override def fooReverse: F[String] = foo.map(_.reverse)
+  }
+
+  // instrumented manually since the Scala 3 version is still experimental
+  implicit def aspect: Aspect[MyAlgebra, Trivial, Trivial] = // cats.tagless.Derive.instrument
+    new Aspect[MyAlgebra, Trivial, Trivial] {
+      def weave[F[_]](af: MyAlgebra[F]): MyAlgebra[Aspect.Weave[F, Trivial, Trivial, *]] = new MyAlgebra[Aspect.Weave[F, Trivial, Trivial, *]] {
+        override def foo: Aspect.Weave[F, Trivial, Trivial, String] = Aspect.Weave("MyAlgebra", List.empty, Aspect.Advice("foo", af.foo))
+        override def fooReverse: Aspect.Weave[F, Trivial, Trivial, String] = Aspect.Weave("MyAlgebra", List.empty, Aspect.Advice("fooReverse", af.fooReverse))
+      }
+
+      override def mapK[F[_], G[_]](af: MyAlgebra[F])(fk: F ~> G): MyAlgebra[G] = new MyAlgebra[G] {
+        override def foo: G[String] = fk(af.foo)
+        override def fooReverse: G[String] = fk(af.fooReverse)
+      }
+    }
+}
+
+class WriteInstrumentation[F[_] : Monad] extends (Instrumentation[WriterT[F, List[String], *], *] ~> WriterT[F, List[String], *]) {
+  override def apply[A](fa: Instrumentation[WriterT[F, List[String], *], A]): WriterT[F, List[String], A] =
+    WriterT.tell(List(s"${fa.algebraName}.${fa.methodName}")) >> fa.value
+}
+
+class WriteWeave[F[_] : Monad] extends (Aspect.Weave[WriterT[F, List[String], *], Trivial, Trivial, *] ~> WriterT[F, List[String], *]) {
+  override def apply[A](fa: Aspect.Weave[WriterT[F, List[String], *], Trivial, Trivial, A]): WriterT[F, List[String], A] =
+    WriterT.tell(List(s"${fa.algebraName}.${fa.codomain.name}")) >> fa.codomain.target
+}


### PR DESCRIPTION
The tests in `WeaveKnotSpec` tell the story. This is motivated by wanting to use this library's `.traceWithInputsAndOutputs` on an algebra that uses its own methods. Without something like this, those nested spans don't appear in the trace, because the instrumentation isn't applied in time. Using `WeaveKnot` fixes the problem.